### PR TITLE
Investigate unit test failure

### DIFF
--- a/app/forms/contributor_search/contributor_search_form.py
+++ b/app/forms/contributor_search/contributor_search_form.py
@@ -19,6 +19,7 @@ from app.utilities.helpers import (
     create_new_dict,
     clean_search_parameters,
     build_uri,
+    build_links,
 )
 from app.utilities.graphql_data import GraphData
 from app.setup import discovery_service

--- a/app/forms/contributor_search/contributor_search_form.py
+++ b/app/forms/contributor_search/contributor_search_form.py
@@ -18,8 +18,7 @@ from app.utilities.helpers import (
     create_form_class,
     create_new_dict,
     clean_search_parameters,
-    build_uri,
-    build_links,
+    build_uri
 )
 from app.utilities.graphql_data import GraphData
 from app.setup import discovery_service

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,5 +1,5 @@
 from app.eureka_config import eureka_config
-from app.forms.contributor_search.contributor_search_form import build_uri, clean_search_parameters, build_links
+from app.forms.contributor_search.contributor_search_form import build_uri, clean_search_parameters
 
 
 def test_build_url_one_param():
@@ -44,16 +44,3 @@ def test_landing_page_exists():
 
 def test_main_page_exists():
     assert eureka_config.mock_contributor_search(url_connect='/Contributor/GeneralSearch').status_code == 200
-
-def test_build_links():
-    links_list = [
-        {"rel": "first", "href": "http://localhost:8080/contributor/searchByLikePageable/reference=499;"
-                                 "period=2017?page=0&size=10&sort=period,asc",
-         "hreflang": "null", "media": "null", "title": "null", "type": "null", "deprecation": "null"},
-        {"rel": "prev", "href": "http://localhost:8080/contributor/searchByLikePageable/reference=499;"
-                                "period=2017?page=4&size=10&sort=period,asc",
-         "hreflang": "null", "media": "null", "title": "null", "type": "null", "deprecation": "null"}]
-    name_of_link = "first"
-    result = build_links(links_list, name_of_link)
-    assert result == "http://localhost:8080/contributor/searchByLikePageable/reference=499;" + \
-                     "period=2017?page=0&size=10&sort=period,asc"

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Run unit tests
+pytest --vv


### PR DESCRIPTION
Build links is deprecated after we stopped using hystrix. I should have removed the unit test when I was working on switching the ContributorSearchScreen over the GQL.