### PR TITLE
Removed reference to favicon/favicon.ico

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,7 +10,6 @@
         <meta content="width=device-width, initial-scale=1" name="viewport">
         <meta name="msapplication-config"
               content="https://cdn.ons.gov.uk/sdc/design-system/16.1.0/favicons/browserconfig.json">
-        <link rel="icon" type="image/x-icon" href="/favicons/favicon.ico">
         <link rel="icon" type="image/png"
               href="https://cdn.ons.gov.uk/sdc/design-system/16.1.0/favicons/favicon-32x32.png" sizes="32x32">
         <link rel="icon" type="image/png"


### PR DESCRIPTION
To stop requests being made to <loadbalancer>/favicons/favicon.ico as this route does not exist.  Potential cause of the UI slow down.