### PR TITLE
Bdd tests in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ vendor/
 
 # BDD-acceptance-tests
 screen_shots/
+tests/acceptance-tests/docker_results/

--- a/Readme.md
+++ b/Readme.md
@@ -68,5 +68,17 @@
         To run in real chrome browser mode just use - behave {featurefile} without the browser option.
  
       
-   
+   - To run tests using a docker image
+      
+      switch to the tests folder cd takeon-ui/tests/ 
+      Run the export command in the terminal to set the url
+                    
+          export TAKEON_URL="URL"
+          
+      Replace URL with the environment url you wish to test.
+      Run the below make command 
+          
+          make docker-run  
+          
+      Finally to see if the tests been run successfully there will be a folder called docker_results gets created automatically after the tests run and will have the screenshots which are been taken after each scenario. 
          

--- a/Readme.md
+++ b/Readme.md
@@ -32,8 +32,9 @@
 
 -  Setting up the environment URL:
 
-        export TAKEON_URL="URL"
+        export TAKEON_URL="http://{URL}"
         Replace URL with the enviroment url you wish to test.
+        Note: make sure while setting up the url it has 'http://' protocol otherwise tests will fail
      
        
 -  To run the BDD tests you need to switch to the features folder first.

--- a/Readme.md
+++ b/Readme.md
@@ -80,5 +80,6 @@
           
           make docker-run  
           
-      Finally to see if the tests been run successfully there will be a folder called docker_results gets created automatically after the tests run and will have the screenshots which are been taken after each scenario. 
+      Finally to see if the tests been run successfully there will be a folder called docker_results gets created automatically after the tests run 
+      and will have the screenshots which are been taken after each scenario. 
          

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,47 @@
+FROM python:3.8
+
+# install google chrome
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+RUN apt-get -y update
+RUN apt-get install -y google-chrome-stable
+
+
+# install chromedriver
+RUN apt-get install -yqq unzip
+RUN wget -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`/chromedriver_linux64.zip
+RUN unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
+
+
+# set display port to avoid crash and dbus env to avoid hanging
+ENV DISPLAY=:99
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+
+
+RUN mkdir /code
+WORKDIR /code
+
+COPY .  /code/
+COPY /acceptance-tests/  /code/acceptance-tests/
+
+
+
+
+RUN pip install --upgrade pip
+RUN pip install -r /code/requirements_local.txt
+
+
+#CMD ["python", "./app.py"]
+
+
+
+
+#ENTRYPOINT ["wrapper.sh"]
+CMD behave -f plain --no-capture
+#CMD /bin/sh wrapper.sh
+# for running for docker file run the command  docker run -ti -w /code/acceptance-tests/ bddsel1
+#run this command for up the yml file docker-compose up -d
+# for running in  docker compose docker run  --network="host" -ti -w /code/acceptance-tests/  bdd-selenium-python_test
+# docker run  --network="host" -v /Users/Mohamf/bdd-selenium-python/acceptance-tests/docker_results:/code/docker_results  -ti -w /code/acceptance-tests/  bdd-dkr-img
+#to enter inside docker image -  docker run -ti --entrypoint=/bin/sh bdd-docker-img1

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -29,4 +29,4 @@ COPY /acceptance-tests/  /code/acceptance-tests/
 RUN pip install --upgrade pip
 RUN pip install -r /code/requirements_local.txt
 
-CMD behave -t @smoke -D browser='docker-browser'
+CMD behave -k --tags=smoke -D browser='docker-browser'

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -29,5 +29,4 @@ COPY /acceptance-tests/  /code/acceptance-tests/
 RUN pip install --upgrade pip
 RUN pip install -r /code/requirements_local.txt
 
-
-CMD behave -f plain --no-capture -D browser='docker-browser'
+CMD behave -t @smoke -D browser='docker-browser'

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -21,10 +21,8 @@ ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 
 RUN mkdir /code
 WORKDIR /code
-
 COPY .  /code/
 COPY /acceptance-tests/  /code/acceptance-tests/
-
 
 
 
@@ -32,16 +30,4 @@ RUN pip install --upgrade pip
 RUN pip install -r /code/requirements_local.txt
 
 
-#CMD ["python", "./app.py"]
-
-
-
-
-#ENTRYPOINT ["wrapper.sh"]
 CMD behave -f plain --no-capture
-#CMD /bin/sh wrapper.sh
-# for running for docker file run the command  docker run -ti -w /code/acceptance-tests/ bddsel1
-#run this command for up the yml file docker-compose up -d
-# for running in  docker compose docker run  --network="host" -ti -w /code/acceptance-tests/  bdd-selenium-python_test
-# docker run  --network="host" -v /Users/Mohamf/bdd-selenium-python/acceptance-tests/docker_results:/code/docker_results  -ti -w /code/acceptance-tests/  bdd-dkr-img
-#to enter inside docker image -  docker run -ti --entrypoint=/bin/sh bdd-docker-img1

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -30,4 +30,4 @@ RUN pip install --upgrade pip
 RUN pip install -r /code/requirements_local.txt
 
 
-CMD behave -f plain --no-capture
+CMD behave -f plain --no-capture -D browser='docker-browser'

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,10 +1,12 @@
 docker-build:
 	docker build -t bdd-tests .
 
+set-url:
+	export TAKEON_URL
+	echo $(TAKEON_URL)
+
 docker-compose:
 	docker-compose up -d
 
-docker-run:
-	export TAKEON_URL
-	echo $(TAKEON_URL)
+docker-run: set-url docker-build
 	docker run  -e TAKEON_URL='$(TAKEON_URL)' -v $(CURDIR)/acceptance-tests/docker_results:/code/docker_results  -ti -w /code/acceptance-tests/ bdd-tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,4 +9,4 @@ docker-compose:
 	docker-compose up -d
 
 docker-run: set-url docker-build
-	docker run  -e TAKEON_URL='$(TAKEON_URL)' -v $(CURDIR)/acceptance-tests/docker_results:/code/docker_results  -ti -w /code/acceptance-tests/ bdd-tests
+	docker run  -e TAKEON_URL='$(TAKEON_URL)' -ti -w /code/acceptance-tests/ bdd-tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,6 +5,6 @@ docker-compose:
 	docker-compose up -d
 
 docker-run:
-	export UI_URL=TAKEON_URL
-	echo $(UI_URL)
-	docker run  -e TAKEON_URL='$(UI_URL)'  -v $(CURDIR)/acceptance-tests/docker_results:/code/docker_results  -ti -w /code/acceptance-tests/ bdd-tests
+	export TAKEON_URL
+	echo $(TAKEON_URL)
+	docker run  -e TAKEON_URL='$(TAKEON_URL)' -v $(CURDIR)/acceptance-tests/docker_results:/code/docker_results  -ti -w /code/acceptance-tests/ bdd-tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,14 +5,6 @@ docker-compose:
 	docker-compose up -d
 
 docker-run:
-	#docker run -ti -w /code/acceptance-tests/ bdd-tests
-#	docker run --name temp-container bdd-tests /bin/sh
-#	docker cp temp-container:/code/acceptance-tests/docker_results /Users/Mohamf/takeon-ui/tests/acceptance-tests/docker_results
-#	docker run -ti -w /code/acceptance-tests/ bdd-tests
-#	docker cp temp-container:/code/acceptance-tests/docker_results /Users/Mohamf/takeon-ui/tests/acceptance-tests/docker_results
-
-	docker run  --network="host" -v /Users/Mohamf/takeon-ui/tests/acceptance-tests/docker_results:/code/docker_results  -ti -w /code/acceptance-tests/ bdd-tests
-
-check-img:
-	docker run -ti --entrypoint=/bin/sh bdd-tests
-
+	export UI_URL=TAKEON_URL
+	echo $(UI_URL)
+	docker run  -e TAKEON_URL='$(UI_URL)'  -v $(CURDIR)/acceptance-tests/docker_results:/code/docker_results  -ti -w /code/acceptance-tests/ bdd-tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,18 @@
+docker-build:
+	docker build -t bdd-tests .
+
+docker-compose:
+	docker-compose up -d
+
+docker-run:
+	#docker run -ti -w /code/acceptance-tests/ bdd-tests
+#	docker run --name temp-container bdd-tests /bin/sh
+#	docker cp temp-container:/code/acceptance-tests/docker_results /Users/Mohamf/takeon-ui/tests/acceptance-tests/docker_results
+#	docker run -ti -w /code/acceptance-tests/ bdd-tests
+#	docker cp temp-container:/code/acceptance-tests/docker_results /Users/Mohamf/takeon-ui/tests/acceptance-tests/docker_results
+
+	docker run  --network="host" -v /Users/Mohamf/takeon-ui/tests/acceptance-tests/docker_results:/code/docker_results  -ti -w /code/acceptance-tests/ bdd-tests
+
+check-img:
+	docker run -ti --entrypoint=/bin/sh bdd-tests
+

--- a/tests/acceptance-tests/base/browser.py
+++ b/tests/acceptance-tests/base/browser.py
@@ -23,23 +23,23 @@ class Browser:
         :return: driver: browser instance
         """
         browser = context.config.userdata.get('browser')
-        screen_shots_loc = ConfigTest.HOMEDIR + '/takeon-ui/tests/acceptance-tests/screen_shots'
 
         if not browser:
             # create instance of the Chrome driver
             DriverContext.driver = webdriver.Chrome(executable_path=ConfigTest.CHROME_DRIVER_LOCATION)
             DriverContext.driver.maximize_window()
-            context.screenshots_dir = screen_shots_loc
         elif browser.lower() == 'headless':
             chrome_options = Options()
-            chrome_options.headless = True
+            chrome_options.add_argument("--headless")
+            chrome_options.add_argument("--no-sandbox")
+            chrome_options.add_argument("--disable-dev-shm-usage")
             chrome_options.add_argument("--window-size=1920,1080")
             chrome_options.add_argument("disable-infobars")
             chrome_options.add_argument("--disable-extensions")
             # create instance of the Chrome driver
-            DriverContext.driver = webdriver.Chrome(executable_path=ConfigTest.CHROME_DRIVER_LOCATION)
+            DriverContext.driver = webdriver.Chrome(executable_path=ConfigTest.CHROME_DRIVER_LOCATION,
+                                                    chrome_options=chrome_options)
             DriverContext.driver.maximize_window()
-            context.screenshots_dir = screen_shots_loc
         elif browser.lower() == 'docker-browser':
             chrome_options = Options()
             chrome_options.add_argument("--headless")
@@ -49,11 +49,9 @@ class Browser:
             chrome_prefs = {}
             chrome_options.experimental_options["prefs"] = chrome_prefs
             chrome_prefs["profile.default_content_settings"] = {"images": 2}
-            DriverContext.driver = webdriver.Chrome(options=chrome_options)
-            context.screenshots_dir = os.path.join('/code/docker_results')
+            DriverContext.driver = webdriver.Chrome(chrome_options=chrome_options)
         else:
             raise Exception("The browser type '{}' is not supported".format(browser))
-        return context.screenshots_dir
 
     @staticmethod
     def navigate_to_the_url():

--- a/tests/acceptance-tests/base/browser.py
+++ b/tests/acceptance-tests/base/browser.py
@@ -2,12 +2,10 @@
 Class containing common functions used in several tests.
 Functions that are not test or feature specific.
 """
-import os
 import time
 
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
-from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.chrome.options import Options
 from base.driver_context import DriverContext
 from config_files.config_test import ConfigTest
@@ -24,7 +22,6 @@ class Browser:
         :return: driver: browser instance
         """
         browser = context.config.userdata.get('browser')
-
         if not browser:
             chrome_options = Options()
             chrome_options.add_argument("--headless")
@@ -48,7 +45,6 @@ class Browser:
             # create instance of the Chrome driver
             DriverContext.driver = webdriver.Chrome(executable_path=ConfigTest.CHROME_DRIVER_LOCATION)
             DriverContext.driver.maximize_window()
-
         else:
             raise Exception("The browser type '{}' is not supported".format(browser))
 
@@ -63,6 +59,7 @@ class Browser:
                 try:
                     current_url = DriverContext.driver.current_url
                     if url != current_url:
+                        print('url is ' + url)
                         DriverContext.driver.get(url)
                         return DriverContext.driver
                 except TimeoutException:

--- a/tests/acceptance-tests/base/browser.py
+++ b/tests/acceptance-tests/base/browser.py
@@ -6,7 +6,7 @@ import os
 import time
 
 from selenium import webdriver
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import TimeoutException, InvalidArgumentException, WebDriverException
 from selenium.webdriver.chrome.options import Options
 from base.driver_context import DriverContext
 from config_files.config_test import ConfigTest
@@ -65,11 +65,21 @@ class Browser:
                     current_url = DriverContext.driver.current_url
                     if url != current_url:
                         print('url is ' + url)
+                        if 'http' not in url:
+                            url = 'http://' + url
+                            print('url with http is ' + url)
                         DriverContext.driver.get(url)
                         return DriverContext.driver
+                except InvalidArgumentException:
+                    assert False, 'Check the url.It needs to contain the http protocol in it: ' + url
                 except TimeoutException:
                     DriverContext.driver.execute_script("window.stop();")
                     assert False, 'Time taken to load the url: ' + str(time.time() - t)
+                except WebDriverException as ex:
+                    print(ex)
+                    if "unknown error: net::ERR_NAME_NOT_RESOLVED" in str(ex):
+                        assert False, ('Unable to Navigate to URL:{} \n'
+                                       'possibly because of the url is not valid'.format(url))
             else:
                 raise ValueError(
                     'Test failed as there was no url been set.\n'

--- a/tests/acceptance-tests/base/browser.py
+++ b/tests/acceptance-tests/base/browser.py
@@ -2,6 +2,7 @@
 Class containing common functions used in several tests.
 Functions that are not test or feature specific.
 """
+import os
 import time
 
 from selenium import webdriver
@@ -22,20 +23,13 @@ class Browser:
         :return: driver: browser instance
         """
         browser = context.config.userdata.get('browser')
+        screen_shots_loc = ConfigTest.HOMEDIR + '/takeon-ui/tests/acceptance-tests/screen_shots'
+
         if not browser:
-            chrome_options = Options()
-            chrome_options.add_argument("--headless")
-            chrome_options.add_argument("--no-sandbox")
-            chrome_options.add_argument("--disable-dev-shm-usage")
-            chrome_options.add_argument("--window-size=1920,1080")
-            chrome_prefs = {}
-            chrome_options.experimental_options["prefs"] = chrome_prefs
-            chrome_prefs["profile.default_content_settings"] = {"images": 2}
-            DriverContext.driver = webdriver.Chrome(options=chrome_options)
-        elif browser.lower() == 'chrome':
             # create instance of the Chrome driver
             DriverContext.driver = webdriver.Chrome(executable_path=ConfigTest.CHROME_DRIVER_LOCATION)
             DriverContext.driver.maximize_window()
+            context.screenshots_dir = screen_shots_loc
         elif browser.lower() == 'headless':
             chrome_options = Options()
             chrome_options.headless = True
@@ -45,8 +39,21 @@ class Browser:
             # create instance of the Chrome driver
             DriverContext.driver = webdriver.Chrome(executable_path=ConfigTest.CHROME_DRIVER_LOCATION)
             DriverContext.driver.maximize_window()
+            context.screenshots_dir = screen_shots_loc
+        elif browser.lower() == 'docker-browser':
+            chrome_options = Options()
+            chrome_options.add_argument("--headless")
+            chrome_options.add_argument("--no-sandbox")
+            chrome_options.add_argument("--disable-dev-shm-usage")
+            chrome_options.add_argument("--window-size=1920,1080")
+            chrome_prefs = {}
+            chrome_options.experimental_options["prefs"] = chrome_prefs
+            chrome_prefs["profile.default_content_settings"] = {"images": 2}
+            DriverContext.driver = webdriver.Chrome(options=chrome_options)
+            context.screenshots_dir = os.path.join('/code/docker_results')
         else:
             raise Exception("The browser type '{}' is not supported".format(browser))
+        return context.screenshots_dir
 
     @staticmethod
     def navigate_to_the_url():

--- a/tests/acceptance-tests/base/browser.py
+++ b/tests/acceptance-tests/base/browser.py
@@ -2,10 +2,12 @@
 Class containing common functions used in several tests.
 Functions that are not test or feature specific.
 """
+import os
 import time
 
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
+from selenium.webdriver import DesiredCapabilities
 from selenium.webdriver.chrome.options import Options
 from base.driver_context import DriverContext
 from config_files.config_test import ConfigTest
@@ -24,6 +26,16 @@ class Browser:
         browser = context.config.userdata.get('browser')
 
         if not browser:
+            chrome_options = Options()
+            chrome_options.add_argument("--headless")
+            chrome_options.add_argument("--no-sandbox")
+            chrome_options.add_argument("--disable-dev-shm-usage")
+            chrome_options.add_argument("--window-size=1920,1080")
+            chrome_prefs = {}
+            chrome_options.experimental_options["prefs"] = chrome_prefs
+            chrome_prefs["profile.default_content_settings"] = {"images": 2}
+            DriverContext.driver = webdriver.Chrome(options=chrome_options)
+        elif browser.lower() == 'chrome':
             # create instance of the Chrome driver
             DriverContext.driver = webdriver.Chrome(executable_path=ConfigTest.CHROME_DRIVER_LOCATION)
             DriverContext.driver.maximize_window()
@@ -33,8 +45,10 @@ class Browser:
             chrome_options.add_argument("--window-size=1920,1080")
             chrome_options.add_argument("disable-infobars")
             chrome_options.add_argument("--disable-extensions")
-            DriverContext.driver = webdriver.Chrome(executable_path=ConfigTest.CHROME_DRIVER_LOCATION,
-                                                    options=chrome_options)
+            # create instance of the Chrome driver
+            DriverContext.driver = webdriver.Chrome(executable_path=ConfigTest.CHROME_DRIVER_LOCATION)
+            DriverContext.driver.maximize_window()
+
         else:
             raise Exception("The browser type '{}' is not supported".format(browser))
 

--- a/tests/acceptance-tests/base/selenium_core.py
+++ b/tests/acceptance-tests/base/selenium_core.py
@@ -105,7 +105,7 @@ class SeleniumCore:
         current_handle = driver.current_window_handle
         for handle in handles:
             if handle != current_handle:
-                driver.switch_to.window(handle)
+                driver.switch_to_window(handle)
                 break
 
     @staticmethod
@@ -116,5 +116,5 @@ class SeleniumCore:
         for handle in handles:
             if handle != current_handle:
                 driver.close()
-                driver.switch_to.window(handle)
+                driver.switch_to_window(handle)
                 break

--- a/tests/acceptance-tests/base/utilities.py
+++ b/tests/acceptance-tests/base/utilities.py
@@ -1,5 +1,6 @@
 import os
 import time
+from sys import platform
 
 from base.driver_context import DriverContext
 
@@ -33,18 +34,25 @@ class Utilities:
     @staticmethod
     def take_screen_shot(*scenario):
         scenario_error_dir = Utilities.create_screen_shots_folder()
-        if scenario[0].status.name == 'failed':
-            scenario_file_path = os.path.join(scenario_error_dir,
-                                              scenario[0].feature.scenarios[0].name + '_line_no_' +
-                                              str(scenario[0].line)
-                                              + '_' + time.strftime("%d_%m_%Y")
-                                              + '.png')
-            DriverContext.driver.save_screenshot(scenario_file_path)
+        # if scenario[0].status.name == 'failed':
+        print("screenshot path: " + scenario_error_dir)
+        scenario_file_path = os.path.join(scenario_error_dir,
+                                          scenario[0].feature.scenarios[0].name + '_line_no_' +
+                                          str(scenario[0].line)
+                                          + '_' + time.strftime("%d_%m_%Y")
+                                          + '.png')
+        print("taken the file path: " + scenario_file_path)
+        DriverContext.driver.save_screenshot(scenario_file_path)
+        print("taken the screenshot")
 
     @staticmethod
     def create_screen_shots_folder():
-        scenario_error_dir = os.path.expanduser("~") + '/takeon-ui/tests/acceptance-tests/screen_shots'
+        # scenario_error_dir = os.path.expanduser("~") + '/takeon-ui/tests/acceptance-tests/screen_shots'
+        scenario_error_dir = os.path.join('/code/docker_results')
+        print("getting the screenshot..be ready!")
+
         if not os.path.exists(scenario_error_dir):
+            print('create new folder')
             os.makedirs(scenario_error_dir)
         else:
             # specify the days from which the files to be deleted
@@ -55,6 +63,7 @@ class Utilities:
             # comparing the days
             if seconds >= ctime:
                 Utilities.delete_all_the_previous_screenshots(scenario_error_dir)
+            print('No need to create new folder')
         return scenario_error_dir
 
     @staticmethod

--- a/tests/acceptance-tests/base/utilities.py
+++ b/tests/acceptance-tests/base/utilities.py
@@ -33,7 +33,7 @@ class Utilities:
     @staticmethod
     def take_screen_shot(*scenario):
         scenario_error_dir = Utilities.create_screen_shots_folder(scenario[1])
-        if scenario[0].status.name == 'failed':
+        if scenario[0].status.name == 'failed' or scenario[1] == '/code/docker_results':
             scenario_file_path = os.path.join(scenario_error_dir,
                                               scenario[0].feature.scenarios[0].name + '_line_no_' +
                                               str(scenario[0].line)

--- a/tests/acceptance-tests/base/utilities.py
+++ b/tests/acceptance-tests/base/utilities.py
@@ -2,6 +2,7 @@ import os
 import time
 
 from base.driver_context import DriverContext
+from config_files.config_test import ConfigTest
 
 
 class Utilities:
@@ -33,9 +34,10 @@ class Utilities:
     @staticmethod
     def take_screen_shot(*scenario_details):
         scenario = scenario_details[0]
-        screenshots_location = scenario_details[1]
+        screenshots_location = ConfigTest.HOMEDIR + '/takeon-ui/tests/acceptance-tests/screen_shots'
+
         scenario_error_dir = Utilities.create_screen_shots_folder(screenshots_location)
-        if scenario.status.name == 'failed' or screenshots_location == '/code/docker_results':
+        if scenario.status.name == 'failed':
             scenario_file_path = os.path.join(scenario_error_dir,
                                               scenario.feature.scenarios[0].name + '_line_no_' +
                                               str(scenario.line)

--- a/tests/acceptance-tests/base/utilities.py
+++ b/tests/acceptance-tests/base/utilities.py
@@ -1,6 +1,5 @@
 import os
 import time
-from sys import platform
 
 from base.driver_context import DriverContext
 
@@ -33,38 +32,33 @@ class Utilities:
 
     @staticmethod
     def take_screen_shot(*scenario):
-        scenario_error_dir = Utilities.create_screen_shots_folder()
-        # if scenario[0].status.name == 'failed':
-        print("screenshot path: " + scenario_error_dir)
-        scenario_file_path = os.path.join(scenario_error_dir,
-                                          scenario[0].feature.scenarios[0].name + '_line_no_' +
-                                          str(scenario[0].line)
-                                          + '_' + time.strftime("%d_%m_%Y")
-                                          + '.png')
-        print("taken the file path: " + scenario_file_path)
-        DriverContext.driver.save_screenshot(scenario_file_path)
-        print("taken the screenshot")
+        scenario_error_dir = Utilities.create_screen_shots_folder(scenario[1])
+        if scenario[0].status.name == 'failed':
+            scenario_file_path = os.path.join(scenario_error_dir,
+                                              scenario[0].feature.scenarios[0].name + '_line_no_' +
+                                              str(scenario[0].line)
+                                              + '_' + time.strftime("%d_%m_%Y")
+                                              + '.png')
+            print("getting the screenshot!")
+            DriverContext.driver.save_screenshot(scenario_file_path)
 
     @staticmethod
-    def create_screen_shots_folder():
-        # scenario_error_dir = os.path.expanduser("~") + '/takeon-ui/tests/acceptance-tests/screen_shots'
-        scenario_error_dir = os.path.join('/code/docker_results')
-        print("getting the screenshot..be ready!")
+    def create_screen_shots_folder(screenshots_loc):
 
-        if not os.path.exists(scenario_error_dir):
+        if not os.path.exists(screenshots_loc):
             print('create new folder')
-            os.makedirs(scenario_error_dir)
+            os.makedirs(screenshots_loc)
         else:
             # specify the days from which the files to be deleted
             days = 1
             # converting days to seconds
             seconds = time.time() - (days * 24 * 60 * 60)
-            ctime = os.stat(scenario_error_dir).st_ctime
+            ctime = os.stat(screenshots_loc).st_ctime
             # comparing the days
             if seconds >= ctime:
-                Utilities.delete_all_the_previous_screenshots(scenario_error_dir)
+                Utilities.delete_all_the_previous_screenshots(screenshots_loc)
             print('No need to create new folder')
-        return scenario_error_dir
+        return screenshots_loc
 
     @staticmethod
     def delete_all_the_previous_screenshots(folder_path):

--- a/tests/acceptance-tests/base/utilities.py
+++ b/tests/acceptance-tests/base/utilities.py
@@ -31,12 +31,14 @@ class Utilities:
         return " ".join(value.split())
 
     @staticmethod
-    def take_screen_shot(*scenario):
-        scenario_error_dir = Utilities.create_screen_shots_folder(scenario[1])
-        if scenario[0].status.name == 'failed' or scenario[1] == '/code/docker_results':
+    def take_screen_shot(*scenario_details):
+        scenario = scenario_details[0]
+        screenshots_location = scenario_details[1]
+        scenario_error_dir = Utilities.create_screen_shots_folder(screenshots_location)
+        if scenario.status.name == 'failed' or screenshots_location == '/code/docker_results':
             scenario_file_path = os.path.join(scenario_error_dir,
-                                              scenario[0].feature.scenarios[0].name + '_line_no_' +
-                                              str(scenario[0].line)
+                                              scenario.feature.scenarios[0].name + '_line_no_' +
+                                              str(scenario.line)
                                               + '_' + time.strftime("%d_%m_%Y")
                                               + '.png')
             print("getting the screenshot!")

--- a/tests/acceptance-tests/features/bmi/search.feature
+++ b/tests/acceptance-tests/features/bmi/search.feature
@@ -25,7 +25,7 @@ Feature: Search function
       | 65900000103 |
       | 4998800105  |
 
-
+  @smoke
   Scenario Outline: Using an existing Survey id
     Given I search for the <survey> with <reference> for the current period <period>
     Then <reference> and <period> and <survey> will be displayed

--- a/tests/acceptance-tests/features/environment.py
+++ b/tests/acceptance-tests/features/environment.py
@@ -5,7 +5,7 @@ from base.utilities import Utilities
 
 
 def before_feature(context, feature):
-    Browser.initialize_the_browser(context)
+    context.screenshots_dir = Browser.initialize_the_browser(context)
 
 
 def before_scenario(context, scenario):
@@ -14,7 +14,7 @@ def before_scenario(context, scenario):
 
 def after_scenario(context, scenario):
     # take screenshot if test failed
-    Utilities.take_screen_shot(scenario)
+    Utilities.take_screen_shot(scenario,context.screenshots_dir)
     SeleniumCore.close_the_current_window()
 
 

--- a/tests/acceptance-tests/features/environment.py
+++ b/tests/acceptance-tests/features/environment.py
@@ -14,7 +14,7 @@ def before_scenario(context, scenario):
 
 def after_scenario(context, scenario):
     # take screenshot if test failed
-    Utilities.take_screen_shot(scenario,context.screenshots_dir)
+    Utilities.take_screen_shot(scenario, context.screenshots_dir)
     SeleniumCore.close_the_current_window()
 
 

--- a/tests/acceptance-tests/features/environment.py
+++ b/tests/acceptance-tests/features/environment.py
@@ -5,7 +5,7 @@ from base.utilities import Utilities
 
 
 def before_feature(context, feature):
-    context.screenshots_dir = Browser.initialize_the_browser(context)
+    Browser.initialize_the_browser(context)
 
 
 def before_scenario(context, scenario):
@@ -14,7 +14,7 @@ def before_scenario(context, scenario):
 
 def after_scenario(context, scenario):
     # take screenshot if test failed
-    Utilities.take_screen_shot(scenario, context.screenshots_dir)
+    Utilities.take_screen_shot(scenario)
     SeleniumCore.close_the_current_window()
 
 

--- a/tests/acceptance-tests/features/test_survey/historic_data.feature
+++ b/tests/acceptance-tests/features/test_survey/historic_data.feature
@@ -3,6 +3,7 @@ Feature: Test Survey - Historic Data
   Background:
     Given As a Business Survey user I set the search criteria options for the forms returned by the contributor
 
+  @smoke
   Scenario Outline: SPP-95 - Check Historic Data matches with Current Period Data
     Given I search for the survey "999A" with <reference> for the current period <period>
     And I submit the "current data" <values> for questions

--- a/tests/acceptance-tests/pages/common/base_page.py
+++ b/tests/acceptance-tests/pages/common/base_page.py
@@ -13,7 +13,8 @@ class BasePage:
     HEADER_TITLE = By.XPATH, "//div[contains(@class,'header__title')]"
 
     def current_page_title(self):
-        return SeleniumCore.find_elements_by(*BasePage.HEADER_TITLE)[0].text
+        element = SeleniumCore.wait_for_element_to_be_displayed(By.XPATH, "//div[contains(@class,'header__title')]")
+        return element.text
 
     def check_page_title(self, page_title):
         current_title = self.current_page_title()

--- a/tests/requirements_local.txt
+++ b/tests/requirements_local.txt
@@ -1,0 +1,2 @@
+selenium==3.141.0
+behave==1.2.6


### PR DESCRIPTION
# Description
Added the capability to run the bdd tests using a docker image
Added smoke tags to 3 tests to run those tests only

# How to test?
switch to the tests folder cd tests/
set the bdd env url export the TAKEON_URL='bdd env url'  in the terminal 
and run the make command: make docker-run and it will build and run the tests in one step.
and check the screenshots in the docker_results to prove the tests been actually run using the docker image.
Added the same details to read me file as well.
