### PR TITLE
Feature/bdd screenshots

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,30 @@
         You can run any one or all tests in headless mode with an additional flag called browser.
         Use - behave {featurefile} -D browser=headless will run in headless mode.
         To run in real chrome browser mode just use - behave {featurefile} without the browser option.
- 
+        
+    
+   - To run tests in order to capture screenshots     
+      
+      The screenshots gets captured whenever a test fails. In order to test screenshots capability we need to force fail the tests.
+     
+      First we need to change directory location to acceptance-tests folder 
+      
+      Example test to run: search feature with smoke tag 
+      change the reference number in this feature file manually for Scenario Outline: Using an existing Survey id 
+      in the example table to an invalid reference number like '1234'
+         
+      Once the tests run completes there will be a new screen_shots folder gets created under the acceptance-tests folder with in that folder 
+      the screen_shots of the failed feature files are saved with the current date and time stamp.      
+           
+      
+      Change the reference 49900000796 manually to 1234 
+      | 066 | 49900000796 | 201903 | to 
+      | 066 | 1234        | 201903 |
+      
+      Then run the below command in the terminal.
+      behave -k --tags=@smoke -D browser=headless will run smoke tests in headless mode.
+       
+   
       
    - To run tests using a docker image
       

--- a/tests/acceptance-tests/base/browser.py
+++ b/tests/acceptance-tests/base/browser.py
@@ -64,7 +64,6 @@ class Browser:
                 try:
                     current_url = DriverContext.driver.current_url
                     if url != current_url:
-                        print('url is ' + url)
                         if 'http' not in url:
                             url = 'http://' + url
                             print('url with http is ' + url)
@@ -88,3 +87,7 @@ class Browser:
 
         except ValueError as e:
             print(e)
+
+    @staticmethod
+    def url():
+        print('url is ' + ConfigTest.UI_URL)

--- a/tests/acceptance-tests/base/utilities.py
+++ b/tests/acceptance-tests/base/utilities.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import time
 
 from base.driver_context import DriverContext
@@ -6,6 +7,7 @@ from config_files.config_test import ConfigTest
 
 
 class Utilities:
+    SCREENSHOTS_LOC = ConfigTest.HOMEDIR + '/takeon-ui/tests/acceptance-tests/screen_shots'
 
     @staticmethod
     def convert_blank_data_value(data):
@@ -34,27 +36,26 @@ class Utilities:
     @staticmethod
     def take_screen_shot(*scenario_details):
         scenario = scenario_details[0]
-        screenshots_location = ConfigTest.HOMEDIR + '/takeon-ui/tests/acceptance-tests/screen_shots'
 
-        scenario_error_dir = Utilities.create_screen_shots_folder(screenshots_location)
         if scenario.status.name == 'failed':
+            Utilities.create_screen_shots_folder()
             scenario_with_line_no = scenario.feature.scenarios[0].name + '_line_no_' + str(scenario.line)
 
-            scenario_file_path = os.path.join(scenario_error_dir,
+            scenario_file_path = os.path.join(Utilities.SCREENSHOTS_LOC,
                                               scenario_with_line_no
                                               + '_' + time.strftime("%H%M%S_%d_%m_%Y")
                                               + '.png')
-
-            for file in os.scandir(screenshots_location):
-                if scenario_with_line_no in file.name:
-                    os.unlink(file.path)
-                    print("remove the previous screenshot! " + file.name)
-        print("take the screenshot! " + scenario_file_path)
-        DriverContext.driver.save_screenshot(scenario_file_path)
+            print("take the screenshot! " + scenario_file_path)
+            DriverContext.driver.save_screenshot(scenario_file_path)
 
     @staticmethod
-    def create_screen_shots_folder(screenshots_loc):
-        if not os.path.exists(screenshots_loc):
+    def delete_screenshots_folder():
+        if os.path.isdir(Utilities.SCREENSHOTS_LOC):
+            shutil.rmtree(Utilities.SCREENSHOTS_LOC)
+            print("removed the screenshots folder!")
+
+    @staticmethod
+    def create_screen_shots_folder():
+        if not os.path.exists(Utilities.SCREENSHOTS_LOC):
             print('create new folder')
-            os.makedirs(screenshots_loc)
-        return screenshots_loc
+            os.makedirs(Utilities.SCREENSHOTS_LOC)

--- a/tests/acceptance-tests/base/utilities.py
+++ b/tests/acceptance-tests/base/utilities.py
@@ -38,13 +38,19 @@ class Utilities:
 
         scenario_error_dir = Utilities.create_screen_shots_folder(screenshots_location)
         if scenario.status.name == 'failed':
+            scenario_with_line_no = scenario.feature.scenarios[0].name + '_line_no_' + str(scenario.line)
+
             scenario_file_path = os.path.join(scenario_error_dir,
-                                              scenario.feature.scenarios[0].name + '_line_no_' +
-                                              str(scenario.line)
-                                              + '_' + time.strftime("%d_%m_%Y")
+                                              scenario_with_line_no
+                                              + '_' + time.strftime("%H%M%S_%d_%m_%Y")
                                               + '.png')
-            print("getting the screenshot!")
-            DriverContext.driver.save_screenshot(scenario_file_path)
+
+            for file in os.scandir(screenshots_location):
+                if scenario_with_line_no in file.name:
+                    os.unlink(file.path)
+                    print("remove the previous screenshot! " + file.name)
+        print("take the screenshot! " + scenario_file_path)
+        DriverContext.driver.save_screenshot(scenario_file_path)
 
     @staticmethod
     def create_screen_shots_folder(screenshots_loc):
@@ -52,9 +58,3 @@ class Utilities:
             print('create new folder')
             os.makedirs(screenshots_loc)
         return screenshots_loc
-
-    @staticmethod
-    def delete_all_the_previous_screenshots(folder_path):
-        for file in os.scandir(folder_path):
-            if file.name.endswith(".png"):
-                os.unlink(file.path)

--- a/tests/acceptance-tests/base/utilities.py
+++ b/tests/acceptance-tests/base/utilities.py
@@ -48,20 +48,9 @@ class Utilities:
 
     @staticmethod
     def create_screen_shots_folder(screenshots_loc):
-
         if not os.path.exists(screenshots_loc):
             print('create new folder')
             os.makedirs(screenshots_loc)
-        else:
-            # specify the days from which the files to be deleted
-            days = 1
-            # converting days to seconds
-            seconds = time.time() - (days * 24 * 60 * 60)
-            ctime = os.stat(screenshots_loc).st_ctime
-            # comparing the days
-            if seconds >= ctime:
-                Utilities.delete_all_the_previous_screenshots(screenshots_loc)
-            print('No need to create new folder')
         return screenshots_loc
 
     @staticmethod

--- a/tests/acceptance-tests/base/utilities.py
+++ b/tests/acceptance-tests/base/utilities.py
@@ -3,11 +3,10 @@ import shutil
 import time
 
 from base.driver_context import DriverContext
-from config_files.config_test import ConfigTest
 
 
 class Utilities:
-    SCREENSHOTS_LOC = ConfigTest.HOMEDIR + '/takeon-ui/tests/acceptance-tests/screen_shots'
+    SCREENSHOTS_LOC = os.getcwd() + '/screen_shots'
 
     @staticmethod
     def convert_blank_data_value(data):

--- a/tests/acceptance-tests/features/environment.py
+++ b/tests/acceptance-tests/features/environment.py
@@ -4,6 +4,10 @@ from base.selenium_core import SeleniumCore
 from base.utilities import Utilities
 
 
+def before_all(context):
+    Utilities.delete_screenshots_folder()
+
+
 def before_feature(context, feature):
     Browser.initialize_the_browser(context)
 

--- a/tests/acceptance-tests/features/environment.py
+++ b/tests/acceptance-tests/features/environment.py
@@ -6,6 +6,7 @@ from base.utilities import Utilities
 
 def before_all(context):
     Utilities.delete_screenshots_folder()
+    Browser.url()
 
 
 def before_feature(context, feature):


### PR DESCRIPTION
# Description
The change is now the screenshots taken previously gets removed before each run.

# How to test?
1) Run smoke tests with any invalid references numbers to make the tests failed(remove any digit in the existing reference number in the scenarios to make it invalid) then there will be a screen_shots folder created  under the acceptance-tests folder path with the screenshots been captured after the tests failed.
 
    There should be 3 screenshots been created.

2) Then re-run the tests and they get deleted on the next run.

3) Check the time stamp of the screenshots images to confirm they were been created as new compared to the previous run.

use the below command to run the tests on dev/bdd env
cd into acceptance folder then run
behave -k --tags=@smoke -D browser=headless

# Links
<!--- Are there any other related PRs to link? -->
<!--- Link to any test data needed for testing. -->