### PR TITLE
Add cognito details to docker

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,10 +2,10 @@
 ### Pre-Requisites
  - Browser: 
     - Chrome
-    - Version: 83.0.4103.61  
+    - Version: <latest> eg:83.0.4103.61
    
  - Chromedriver:
-    - Chromedriver version - 83.0.4103.39
+    - Chromedriver version - <compatible to browser version> eg:83.0.4103.39
    
       As long as the browser version and chromedriver are compatible to each other even if you don't have the same browser version mentioned here and you can check that in 
       https://chromedriver.chromium.org/downloads when downloading the chromedriver if not the tests will fail.
@@ -31,9 +31,11 @@
 ### Running Tests
 
 -  Setting up the environment:
-
-        export TAKEON_URL="http://{URL}"
-        export COGNITO_USER_POOL="{COGNITO_USER_POOL}"
+        export AWS_ACCESS_KEY_ID="<AWS_ACCESS_KEY_ID>"
+        export AWS_SECRET_ACCESS_KEY="<AWS_SECRET_ACCESS_KEY>"
+        export AWS_SESSION_TOKEN="<AWS_SESSION_TOKEN>" 
+        export TAKEON_URL="http://<URL>"
+        export COGNITO_USER_POOL="<COGNITO_USER_POOL>"
         Replace URL with the enviroment url you wish to test.
         Note: make sure while setting up the url it has 'http://' protocol otherwise tests will fail
      
@@ -96,15 +98,22 @@
    - To run tests using a docker image
       
       switch to the tests folder cd takeon-ui/tests/ 
-      Run the export command in the terminal to set the url
-                    
-          export TAKEON_URL="URL"
+      Run the export below commands in the terminal to set the AWS Credentials, Env Url and cognito user pool
           
-      Replace URL with the environment url you wish to test.
+          export AWS_ACCESS_KEY_ID="<AWS_ACCESS_KEY_ID>"
+          export AWS_SECRET_ACCESS_KEY="<AWS_SECRET_ACCESS_KEY>"
+          export AWS_SESSION_TOKEN="<AWS_SESSION_TOKEN>"          
+          export TAKEON_URL="http://<URL>"
+          export TAKEON_URL="<COGNITO_USER_POOL>"
+        
       Run the below make command 
-          
+                 
           make docker-run  
-          
-      Finally to see if the tests been run successfully there will be a folder called docker_results gets created automatically after the tests run 
-      and will have the screenshots which are been taken after each scenario. 
-         
+            
+      Finally  you will see the test result like this
+        
+            
+          2 features passed, 0 failed, 52 skipped
+          3 scenarios passed, 0 failed, 435 skipped
+          23 steps passed, 0 failed, 3577 skipped, 0 undefined
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,4 +11,5 @@ docker-compose:
 	docker-compose up -d
 
 docker-run: set-url docker-build
-	docker run -e TAKEON_URL='$(TAKEON_URL)' -e COGNITO_USER_POOL='$(COGNITO_USER_POOL)' -ti -w /code/acceptance-tests/ bdd-tests
+	docker run -e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) -e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) -e AWS_SESSION_TOKEN=$(AWS_SESSION_TOKEN)  -e TAKEON_URL='$(TAKEON_URL)' -e COGNITO_USER_POOL='$(COGNITO_USER_POOL)' -ti -w /code/acceptance-tests/ bdd-tests
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,10 +3,12 @@ docker-build:
 
 set-url:
 	export TAKEON_URL
+	export COGNITO_USER_POOL
 	echo $(TAKEON_URL)
+	echo $(COGNITO_USER_POOL)
 
 docker-compose:
 	docker-compose up -d
 
 docker-run: set-url docker-build
-	docker run  -e TAKEON_URL='$(TAKEON_URL)' -ti -w /code/acceptance-tests/ bdd-tests
+	docker run -e TAKEON_URL='$(TAKEON_URL)' -e COGNITO_USER_POOL='$(COGNITO_USER_POOL)' -ti -w /code/acceptance-tests/ bdd-tests

--- a/tests/requirements_local.txt
+++ b/tests/requirements_local.txt
@@ -1,2 +1,7 @@
 selenium==3.141.0
 behave==1.2.6
+boto3==1.16.7
+botocore==1.19.7
+flake8==3.7.7
+flake8-polyfill==1.0.2
+spp-cognito-auth @ git+https://github.com/ONSdigital/spp-cognito-auth.git@a428c0af471710e885cad1056074ffb9db3456b9


### PR DESCRIPTION
# Description
Added cognito pool to makefile which is required before running the tests.

# How to test?
Run the command to run smoke tests.
change to tests location.
cd tests/
export TAKEON_URL=<BDD2 URL>
export COGNITO_USER_POOL=<BDD2 COGNITO_USER_POOL>
run  below command to check if tests passes 
`make docker-run`
ask me if you don't have bdd2 url or cognito user pool name
