### PR TITLE
Tech/spp 916/upgrade python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as base
+FROM python:3.9-slim as base
 
 
 # Download and resolve any dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests==2.25.0
 requests-mock==1.6.0
 selenium==3.141.0
 WTForms==2.2.1
-gevent==1.5.0
+gevent==21.1.2
 greenlet==1.0.0
 gunicorn==20.1.0
 behave==1.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ requests-mock==1.6.0
 selenium==3.141.0
 WTForms==2.2.1
 gevent==1.5.0
-greenlet=1.0.0
+greenlet==1.0.0
 gunicorn==21.0.0
 behave==1.2.6
 boto3==1.16.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ requests-mock==1.6.0
 selenium==3.141.0
 WTForms==2.2.1
 gevent==1.5.0
-greenlet==0.4.15
-gunicorn==19.9.0
+greenlet=1.0.0
+gunicorn==21.0.0
 behave==1.2.6
 boto3==1.16.7
 botocore==1.19.7
@@ -18,4 +18,4 @@ flake8==3.7.7
 flake8-polyfill==1.0.2
 spp-cognito-auth @ git+https://github.com/ONSdigital/spp-cognito-auth.git@a428c0af471710e885cad1056074ffb9db3456b9
 spp-logger @ git+https://github.com/ONSdigital/spp-logger.git@609c91c85fb9f4a3c75c06c4eec60ad81034dbd5
-immutables==0.14
+immutables==0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ selenium==3.141.0
 WTForms==2.2.1
 gevent==1.5.0
 greenlet==1.0.0
-gunicorn==21.0.0
+gunicorn==20.1.0
 behave==1.2.6
 boto3==1.16.7
 botocore==1.19.7


### PR DESCRIPTION
# Description
The python version in the ui container has been upgraded to 3.9 and the gunicorn version has been upgraded to 20.1.0. Any dependencies that had conflict with the upgraded versions have also been upgraded namely: gevent, greenlet, and immutables.
https://collaborate2.ons.gov.uk/jira/browse/SPP-916
No refactoring has been done just version changes.

# How to test?
Unit tests were ran during the build and test data was loaded into the environment to do a manual UI test.
The only test data used was the 999A test survey data

# Links
No other links